### PR TITLE
Add invoice data protection checkbox to shop payment ui

### DIFF
--- a/wirecardpaymentgateway/translations/de.php
+++ b/wirecardpaymentgateway/translations/de.php
@@ -249,6 +249,8 @@ $_MODULE['<{wirecardpaymentgateway}prestashop>form_fdfdc9b072cbb18c8956190275b47
 $_MODULE['<{wirecardpaymentgateway}prestashop>form_a60dee7af8c325090597391f009b9125'] = 'Status';
 $_MODULE['<{wirecardpaymentgateway}prestashop>form_df671beba83658f3f51777f302c59a6e'] = 'Nachricht';
 $_MODULE['<{wirecardpaymentgateway}prestashop>creditcard_submitform_93f05ad4c93885541f619d9bb1320106'] = 'Sie werden weitergeleitet. Bitte warten.';
+$_MODULE['<{wirecardpaymentgateway}prestashop>invoice_c78f9b2a75c840335bea59dcad2e4925'] = 'Hiermit bestätige ich, dass ich die <a target=\"_blank\" href=\"https://www.wirecardbank.de/privacy-documents/datenschutzhinweis-fur-die-wirecard-zahlarten/\">Datenschutzhinweise</a> und zusätzliche <a target=\"_blank\" href=\"https://www.wirecardbank.de/privacy-documents/zusatzliche-geschaftsbedingungen-fur-wirecard-zahlarten/\">Geschäftsbedingungen</a> für Wirecard-Zahlarten zur Kenntnis genommen habe und mit deren Geltung einverstanden bin.';
+$_MODULE['<{wirecardpaymentgateway}prestashop>invoice_3471b47ae35836a5c315c049f13b211e'] = 'Sie müssen den Datenschutzhinweisen und zusätzlichen Geschäftsbedingungen für Wirecard-Zahlarten zustimmen.';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepadirectdebit_65c55738e0d21515c1e026a8dd7eae21'] = 'First name';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepadirectdebit_b7250955039269f0611a6dab9c340ae9'] = 'Last name';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepadirectdebit_945122a0f892e1b60519029eff19f89e'] = 'IBAN';

--- a/wirecardpaymentgateway/translations/de.php
+++ b/wirecardpaymentgateway/translations/de.php
@@ -263,6 +263,7 @@ $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_90670c9825ff22ac3b244
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_71353177545077b0c97f8c9075f7fc0e'] = 'BIC:';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_57f4ff8becdd21208472e3d09f559fd5'] = 'Ich ermächtige die Firma';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_611a2f2d26601b6c7047646c83ba931e'] = 'einmalig eine Zahlung von meinem Konto mittels SEPA Lastschrift einzuziehen. Zugleich weise ich mein Kreditinstitut an, die von der Firma';
+$_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_cc3c3e790926bfa8dd07838c06121ee0'] = 'auf mein Konto gezogene SEPA Lastschrift einzulösen.';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_63abdba9b6dbccdb53ca1fd0f2e2ad12'] = 'Hinweis: Ich kann innerhalb von acht Wochen, beginnend mit dem Belastungsdatum, die Erstattung des belasteten Betrags verlangen. Es gelten dabei die mit meinem Kreditinstitut vereinbarten Bedingungen.';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_31c4756b8961934302d919b693e2e3a1'] = 'Für den Fall der Nichteinlösung der Lastschrift oder des Widerspruchs gegen die Lastschrift weise ich meine Bank unwiderruflich an, der Firma';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_4f75ff5e69e0c6f3dd89447b2b39c4e7'] = 'oder Dritten auf Anforderung meinen Namen, Adresse und Geburtsdatum vollständig mitzuteilen.';

--- a/wirecardpaymentgateway/translations/en.php
+++ b/wirecardpaymentgateway/translations/en.php
@@ -249,6 +249,8 @@ $_MODULE['<{wirecardpaymentgateway}prestashop>form_fdfdc9b072cbb18c8956190275b47
 $_MODULE['<{wirecardpaymentgateway}prestashop>form_a60dee7af8c325090597391f009b9125'] = 'Status';
 $_MODULE['<{wirecardpaymentgateway}prestashop>form_df671beba83658f3f51777f302c59a6e'] = 'Message';
 $_MODULE['<{wirecardpaymentgateway}prestashop>creditcard_submitform_93f05ad4c93885541f619d9bb1320106'] = 'You are being redirected. Please wait.';
+$_MODULE['<{wirecardpaymentgateway}prestashop>invoice_c78f9b2a75c840335bea59dcad2e4925'] = 'I herewith confirm that I have read the <a href=\"https://www.wirecardbank.com/privacy-documents/datenschutzhinweise-fuer-die-wirecard-zahlarten/\" target=\"_blank\">privacy notice</a> and <a target=\"_blank\" href=\"https://www.wirecardbank.com/privacy-documents/zusatzliche-geschaftsbedingungen-fur-wirecard-zahlarten/\">additional terms and conditions</a> for Wirecard payment types and that I accept their validity.';
+$_MODULE['<{wirecardpaymentgateway}prestashop>invoice_3471b47ae35836a5c315c049f13b211e'] = 'You must agree to the privacy notice and additional terms of Wirecard payment methods.';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepadirectdebit_65c55738e0d21515c1e026a8dd7eae21'] = 'First Name';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepadirectdebit_b7250955039269f0611a6dab9c340ae9'] = 'Last Name';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepadirectdebit_945122a0f892e1b60519029eff19f89e'] = 'IBAN';

--- a/wirecardpaymentgateway/translations/en.php
+++ b/wirecardpaymentgateway/translations/en.php
@@ -263,6 +263,7 @@ $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_90670c9825ff22ac3b244
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_71353177545077b0c97f8c9075f7fc0e'] = 'BIC';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_57f4ff8becdd21208472e3d09f559fd5'] = 'I authorize the creditor';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_611a2f2d26601b6c7047646c83ba931e'] = 'to send instructions to my bank to collect one single direct debit from my account. At the same time I instruct my bank to debit my account in accordance with the instructions from the creditor';
+$_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_cc3c3e790926bfa8dd07838c06121ee0'] = '.';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_63abdba9b6dbccdb53ca1fd0f2e2ad12'] = 'Note: As part of my rights, I am entitled to a refund under the terms and conditions of my agreement with my bank. A refund must be claimed within 8 weeks starting from the date on which my account was debited.';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_31c4756b8961934302d919b693e2e3a1'] = 'I irrevocably agree that, in the event that the direct debit is not honored, or objection against the direct debit exists, my bank will disclose to the creditor';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_4f75ff5e69e0c6f3dd89447b2b39c4e7'] = 'my full name, address and date of birth.';

--- a/wirecardpaymentgateway/translations/id.php
+++ b/wirecardpaymentgateway/translations/id.php
@@ -249,6 +249,8 @@ $_MODULE['<{wirecardpaymentgateway}prestashop>form_fdfdc9b072cbb18c8956190275b47
 $_MODULE['<{wirecardpaymentgateway}prestashop>form_a60dee7af8c325090597391f009b9125'] = 'Status';
 $_MODULE['<{wirecardpaymentgateway}prestashop>form_df671beba83658f3f51777f302c59a6e'] = 'Pesan';
 $_MODULE['<{wirecardpaymentgateway}prestashop>creditcard_submitform_93f05ad4c93885541f619d9bb1320106'] = 'Koneksi Anda sedang dialihkan, harap menunggu';
+$_MODULE['<{wirecardpaymentgateway}prestashop>invoice_c78f9b2a75c840335bea59dcad2e4925'] = 'I herewith confirm that I have read the <a href=\"https://www.wirecardbank.com/privacy-documents/datenschutzhinweise-fuer-die-wirecard-zahlarten/\" target=\"_blank\">privacy notice</a> and <a target=\"_blank\" href=\"https://www.wirecardbank.com/privacy-documents/zusatzliche-geschaftsbedingungen-fur-wirecard-zahlarten/\">additional terms and conditions</a> for Wirecard payment types and that I accept their validity.';
+$_MODULE['<{wirecardpaymentgateway}prestashop>invoice_3471b47ae35836a5c315c049f13b211e'] = 'You must agree to the privacy notice and additional terms of Wirecard payment methods.';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepadirectdebit_65c55738e0d21515c1e026a8dd7eae21'] = 'Nama Depan';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepadirectdebit_b7250955039269f0611a6dab9c340ae9'] = 'Nama Belakang';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepadirectdebit_945122a0f892e1b60519029eff19f89e'] = 'IBAN';
@@ -271,7 +273,7 @@ $_MODULE['<{wirecardpaymentgateway}prestashop>creditcard_f0a5e748d9be590b9fc4a95
 $_MODULE['<{wirecardpaymentgateway}prestashop>creditcard_de1c13a642c022356636de5f2b6ed8c6'] = 'Pilihan kartu kredit';
 $_MODULE['<{wirecardpaymentgateway}prestashop>creditcard_10aec35353f9c4096a71c38654c3d402'] = 'Cancel';
 $_MODULE['<{wirecardpaymentgateway}prestashop>creditcard_4eb57eb6288bc1ae4efd419ff4a3b4ca'] = 'Gunakan Kartu Kredit yang tersimpan';
-$_MODULE['<{wirecardpaymentgateway}prestashop>creditcard_dd6655a20f19076c518afd9a4e534da5'] = 'Kartu Kredit dipilih. Untuk menggunakan Kartu Kredit lain, klik \\\"Gunakan Kartu Kredit baru\\\"';
+$_MODULE['<{wirecardpaymentgateway}prestashop>creditcard_dd6655a20f19076c518afd9a4e534da5'] = 'Kartu Kredit dipilih. Untuk menggunakan Kartu Kredit lain, klik \"Gunakan Kartu Kredit baru\"';
 $_MODULE['<{wirecardpaymentgateway}prestashop>creditcard_5809325b75110f574df44ec5eec4032b'] = 'Gunakan Kartu Kredit baru';
 $_MODULE['<{wirecardpaymentgateway}prestashop>creditcard_5a8a180808e7b94259768ce42bab4c4e'] = 'Simpan untuk digunakan di kemudian hari.';
 $_MODULE['<{wirecardpaymentgateway}prestashop>ideal_cc58efdf2d5748696717291d583d9ef8'] = 'Bank';

--- a/wirecardpaymentgateway/translations/id.php
+++ b/wirecardpaymentgateway/translations/id.php
@@ -263,6 +263,7 @@ $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_90670c9825ff22ac3b244
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_71353177545077b0c97f8c9075f7fc0e'] = 'BIC:';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_57f4ff8becdd21208472e3d09f559fd5'] = 'Saya mengizinkan kreditor';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_611a2f2d26601b6c7047646c83ba931e'] = 'untuk mengirimkan instruksi ke bank saya untuk mengumpulkan satu debit langsung dari akun saya. Pada waktu yang sama saya menginstruksikan bank untuk mendebit akun saya sesuai dengan instruksi dari kreditor';
+$_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_cc3c3e790926bfa8dd07838c06121ee0'] = '.';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_63abdba9b6dbccdb53ca1fd0f2e2ad12'] = 'Catatan: Sebagai bagian dari hak saya, saya berhak atas pengembalian dana sesuai dengan syarat dan ketentuan perjanjian saya dengan bank. Pengembalian dana harus diklaim dalam waktu 8 minggu dimulai dari tanggal akun saya didebit.';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_31c4756b8961934302d919b693e2e3a1'] = 'Saya menyatakan persetujuan yang tidak dapat dibatalkan bahwa jika debit langsung tidak ditanggapi, atau terdapat keberatan atas debit langsung tersebut, bank saya akan mengungkapkan kepada kreditor';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_4f75ff5e69e0c6f3dd89447b2b39c4e7'] = 'nama lengkap, alamat, dan tanggal lahir saya.';

--- a/wirecardpaymentgateway/translations/ja.php
+++ b/wirecardpaymentgateway/translations/ja.php
@@ -263,6 +263,7 @@ $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_90670c9825ff22ac3b244
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_71353177545077b0c97f8c9075f7fc0e'] = 'BIC:';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_57f4ff8becdd21208472e3d09f559fd5'] = '債権者が';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_611a2f2d26601b6c7047646c83ba931e'] = '私の口座から1回のダイレクトデビットを回収するように、私の銀行に指示を送信することを許可します。同時に、私は、債権者からの指示に従い、私の銀行が口座から引き落とすように銀行に指示します。';
+$_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_cc3c3e790926bfa8dd07838c06121ee0'] = '.';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_63abdba9b6dbccdb53ca1fd0f2e2ad12'] = '注記：私の権利の一部として、私は、銀行との合意の条項および条件に基づき、返金を受け取る資格があります。返金は、私の口座から引き落としがあった日から起算して8週間以内に請求する必要があります。';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_31c4756b8961934302d919b693e2e3a1'] = '私は、取消不能の形式で、ダイレクトデビットが無効になった場合や、ダイレクトデビットに対する異議が存在する場合には、私の銀行が債権者';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_4f75ff5e69e0c6f3dd89447b2b39c4e7'] = 'に対して私の氏名、住所、生年月日を開示することに同意します。';

--- a/wirecardpaymentgateway/translations/ja.php
+++ b/wirecardpaymentgateway/translations/ja.php
@@ -249,6 +249,8 @@ $_MODULE['<{wirecardpaymentgateway}prestashop>form_fdfdc9b072cbb18c8956190275b47
 $_MODULE['<{wirecardpaymentgateway}prestashop>form_a60dee7af8c325090597391f009b9125'] = 'ステータス';
 $_MODULE['<{wirecardpaymentgateway}prestashop>form_df671beba83658f3f51777f302c59a6e'] = 'メッセージ';
 $_MODULE['<{wirecardpaymentgateway}prestashop>creditcard_submitform_93f05ad4c93885541f619d9bb1320106'] = 'リダイレクトしています。お待ちください';
+$_MODULE['<{wirecardpaymentgateway}prestashop>invoice_c78f9b2a75c840335bea59dcad2e4925'] = 'I herewith confirm that I have read the <a href=\"https://www.wirecardbank.com/privacy-documents/datenschutzhinweise-fuer-die-wirecard-zahlarten/\" target=\"_blank\">privacy notice</a> and <a target=\"_blank\" href=\"https://www.wirecardbank.com/privacy-documents/zusatzliche-geschaftsbedingungen-fur-wirecard-zahlarten/\">additional terms and conditions</a> for Wirecard payment types and that I accept their validity.';
+$_MODULE['<{wirecardpaymentgateway}prestashop>invoice_3471b47ae35836a5c315c049f13b211e'] = 'You must agree to the privacy notice and additional terms of Wirecard payment methods.';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepadirectdebit_65c55738e0d21515c1e026a8dd7eae21'] = '名';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepadirectdebit_b7250955039269f0611a6dab9c340ae9'] = '姓';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepadirectdebit_945122a0f892e1b60519029eff19f89e'] = 'IBAN';

--- a/wirecardpaymentgateway/translations/ko.php
+++ b/wirecardpaymentgateway/translations/ko.php
@@ -249,6 +249,8 @@ $_MODULE['<{wirecardpaymentgateway}prestashop>form_fdfdc9b072cbb18c8956190275b47
 $_MODULE['<{wirecardpaymentgateway}prestashop>form_a60dee7af8c325090597391f009b9125'] = '상태';
 $_MODULE['<{wirecardpaymentgateway}prestashop>form_df671beba83658f3f51777f302c59a6e'] = '메시지';
 $_MODULE['<{wirecardpaymentgateway}prestashop>creditcard_submitform_93f05ad4c93885541f619d9bb1320106'] = '리디렉션 중입니다. 잠시 기다려주십시오';
+$_MODULE['<{wirecardpaymentgateway}prestashop>invoice_c78f9b2a75c840335bea59dcad2e4925'] = 'I herewith confirm that I have read the <a href=\"https://www.wirecardbank.com/privacy-documents/datenschutzhinweise-fuer-die-wirecard-zahlarten/\" target=\"_blank\">privacy notice</a> and <a target=\"_blank\" href=\"https://www.wirecardbank.com/privacy-documents/zusatzliche-geschaftsbedingungen-fur-wirecard-zahlarten/\">additional terms and conditions</a> for Wirecard payment types and that I accept their validity.';
+$_MODULE['<{wirecardpaymentgateway}prestashop>invoice_3471b47ae35836a5c315c049f13b211e'] = 'You must agree to the privacy notice and additional terms of Wirecard payment methods.';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepadirectdebit_65c55738e0d21515c1e026a8dd7eae21'] = '이름';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepadirectdebit_b7250955039269f0611a6dab9c340ae9'] = '성';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepadirectdebit_945122a0f892e1b60519029eff19f89e'] = 'IBAN';

--- a/wirecardpaymentgateway/translations/ko.php
+++ b/wirecardpaymentgateway/translations/ko.php
@@ -263,6 +263,7 @@ $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_90670c9825ff22ac3b244
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_71353177545077b0c97f8c9075f7fc0e'] = 'BIC:';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_57f4ff8becdd21208472e3d09f559fd5'] = '본인은 채권자가 본인의 계좌에서';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_611a2f2d26601b6c7047646c83ba931e'] = '한 건의 자동 이체를 수취할 수 있도록 은행에 요청합니다. 또한, 본인은 채권자의 지시에 따라 계좌에서 금액을 인출하도록 은행에 요청합니다';
+$_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_cc3c3e790926bfa8dd07838c06121ee0'] = '.';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_63abdba9b6dbccdb53ca1fd0f2e2ad12'] = '참고: 본인은 권리의 일부로서, 은행 이용 약관에 따라 환불받을 권리가 있습니다. 환불은 본인 계좌에서 인출된 날로부터 8주 이내에 청구되어야 합니다.';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_31c4756b8961934302d919b693e2e3a1'] = '본인의 계좌에서 금액이 이체되지 않거나 계좌 이체에 이의가 제기될 경우, 은행은 채권자';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_4f75ff5e69e0c6f3dd89447b2b39c4e7'] = '에게 본인의 성명, 주소, 생년월일을 제공합니다.';

--- a/wirecardpaymentgateway/translations/pl.php
+++ b/wirecardpaymentgateway/translations/pl.php
@@ -249,6 +249,8 @@ $_MODULE['<{wirecardpaymentgateway}prestashop>form_fdfdc9b072cbb18c8956190275b47
 $_MODULE['<{wirecardpaymentgateway}prestashop>form_a60dee7af8c325090597391f009b9125'] = 'Status';
 $_MODULE['<{wirecardpaymentgateway}prestashop>form_df671beba83658f3f51777f302c59a6e'] = 'Wiadomość';
 $_MODULE['<{wirecardpaymentgateway}prestashop>creditcard_submitform_93f05ad4c93885541f619d9bb1320106'] = 'You are being redirected. Please wait.';
+$_MODULE['<{wirecardpaymentgateway}prestashop>invoice_c78f9b2a75c840335bea59dcad2e4925'] = 'I herewith confirm that I have read the <a href=\"https://www.wirecardbank.com/privacy-documents/datenschutzhinweise-fuer-die-wirecard-zahlarten/\" target=\"_blank\">privacy notice</a> and <a target=\"_blank\" href=\"https://www.wirecardbank.com/privacy-documents/zusatzliche-geschaftsbedingungen-fur-wirecard-zahlarten/\">additional terms and conditions</a> for Wirecard payment types and that I accept their validity.';
+$_MODULE['<{wirecardpaymentgateway}prestashop>invoice_3471b47ae35836a5c315c049f13b211e'] = 'You must agree to the privacy notice and additional terms of Wirecard payment methods.';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepadirectdebit_65c55738e0d21515c1e026a8dd7eae21'] = 'Imię';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepadirectdebit_b7250955039269f0611a6dab9c340ae9'] = 'Nazwisko';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepadirectdebit_945122a0f892e1b60519029eff19f89e'] = 'IBAN';

--- a/wirecardpaymentgateway/translations/pl.php
+++ b/wirecardpaymentgateway/translations/pl.php
@@ -263,6 +263,7 @@ $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_90670c9825ff22ac3b244
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_71353177545077b0c97f8c9075f7fc0e'] = 'BIC';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_57f4ff8becdd21208472e3d09f559fd5'] = 'Upoważniam odbiorce';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_611a2f2d26601b6c7047646c83ba931e'] = 'aby wysłać instrukcje do mojego banku na pobranie jednego pojedynczego polecenia zapłaty z mojego konta. Tym samym upoważniam mój bank do obciążania mojego konta zgodnie z instrukcjami odbiorcy.';
+$_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_cc3c3e790926bfa8dd07838c06121ee0'] = '.';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_63abdba9b6dbccdb53ca1fd0f2e2ad12'] = 'Uwaga: W ramach moich praw, mam upoważnienie do zwrotu na mocy zasad i warunków umowy z moim bankiem. O refundację muszę wystąpić w ciągu 8 tygodni od dnia, w którym moje konto zostało obciążone.  ';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_31c4756b8961934302d919b693e2e3a1'] = 'Nieodwołalnie zezwalam, że w przypadku, gdy polecenie zapłaty nie jest honorowane lub istnieje sprzeciw wobec zapłaty, mój bank może ujawnić to do odbiorcy.';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_4f75ff5e69e0c6f3dd89447b2b39c4e7'] = 'Moje pełne imię, adres oraz data urodzenia.';

--- a/wirecardpaymentgateway/translations/tw.php
+++ b/wirecardpaymentgateway/translations/tw.php
@@ -249,6 +249,8 @@ $_MODULE['<{wirecardpaymentgateway}prestashop>form_fdfdc9b072cbb18c8956190275b47
 $_MODULE['<{wirecardpaymentgateway}prestashop>form_a60dee7af8c325090597391f009b9125'] = '狀態';
 $_MODULE['<{wirecardpaymentgateway}prestashop>form_df671beba83658f3f51777f302c59a6e'] = '訊息';
 $_MODULE['<{wirecardpaymentgateway}prestashop>creditcard_submitform_93f05ad4c93885541f619d9bb1320106'] = '您正在重新導向，請稍候';
+$_MODULE['<{wirecardpaymentgateway}prestashop>invoice_c78f9b2a75c840335bea59dcad2e4925'] = 'I herewith confirm that I have read the <a href=\"https://www.wirecardbank.com/privacy-documents/datenschutzhinweise-fuer-die-wirecard-zahlarten/\" target=\"_blank\">privacy notice</a> and <a target=\"_blank\" href=\"https://www.wirecardbank.com/privacy-documents/zusatzliche-geschaftsbedingungen-fur-wirecard-zahlarten/\">additional terms and conditions</a> for Wirecard payment types and that I accept their validity.';
+$_MODULE['<{wirecardpaymentgateway}prestashop>invoice_3471b47ae35836a5c315c049f13b211e'] = 'You must agree to the privacy notice and additional terms of Wirecard payment methods.';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepadirectdebit_65c55738e0d21515c1e026a8dd7eae21'] = '名字';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepadirectdebit_b7250955039269f0611a6dab9c340ae9'] = '姓氏';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepadirectdebit_945122a0f892e1b60519029eff19f89e'] = 'IBAN';

--- a/wirecardpaymentgateway/translations/tw.php
+++ b/wirecardpaymentgateway/translations/tw.php
@@ -263,6 +263,7 @@ $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_90670c9825ff22ac3b244
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_71353177545077b0c97f8c9075f7fc0e'] = 'BIC:';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_57f4ff8becdd21208472e3d09f559fd5'] = '我授權債權人';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_611a2f2d26601b6c7047646c83ba931e'] = '向我的銀行傳送指令，從我的帳戶直接扣除單筆款項。同時，我指示我的銀行依照債權人的指示從我的賬戶中扣款';
+$_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_cc3c3e790926bfa8dd07838c06121ee0'] = '。';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_63abdba9b6dbccdb53ca1fd0f2e2ad12'] = '附註：作為我的權利的一部分，我有權根據我與我的銀行達成的協議條款及條件退款。退款必須在從我的賬戶中扣款之日起的 8 週內申請。';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_31c4756b8961934302d919b693e2e3a1'] = '我不可撤銷地同意，倘若直接扣款未獲兌現或對直接扣款存在異議，我的銀行將向債權人';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_4f75ff5e69e0c6f3dd89447b2b39c4e7'] = '披露我的全名、地址以及出生日期。';

--- a/wirecardpaymentgateway/translations/zh.php
+++ b/wirecardpaymentgateway/translations/zh.php
@@ -263,6 +263,7 @@ $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_90670c9825ff22ac3b244
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_71353177545077b0c97f8c9075f7fc0e'] = 'BIC:';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_57f4ff8becdd21208472e3d09f559fd5'] = '我授权该贷方';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_611a2f2d26601b6c7047646c83ba931e'] = '向我的银行发送指示，以便从我的账户中直接收取一笔账目。与此同时，我指派我的银行根据贷方的指示在我的账户上记录相应的债务。';
+$_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_cc3c3e790926bfa8dd07838c06121ee0'] = '。';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_63abdba9b6dbccdb53ca1fd0f2e2ad12'] = '备注：作为我权力的一部分，根据我与银行之间协议的使用条款，我应当获得退款。该退款必须在我账户计入债务起的 8 周内索取。';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_31c4756b8961934302d919b693e2e3a1'] = '我不可撤销地同意，当无法如期执行直接扣款或是直接扣款受到阻碍时，我的银行可以向贷方';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepa_mandate_4f75ff5e69e0c6f3dd89447b2b39c4e7'] = '公布我的全名、地址以及出生日期。';

--- a/wirecardpaymentgateway/translations/zh.php
+++ b/wirecardpaymentgateway/translations/zh.php
@@ -249,6 +249,8 @@ $_MODULE['<{wirecardpaymentgateway}prestashop>form_fdfdc9b072cbb18c8956190275b47
 $_MODULE['<{wirecardpaymentgateway}prestashop>form_a60dee7af8c325090597391f009b9125'] = '状态';
 $_MODULE['<{wirecardpaymentgateway}prestashop>form_df671beba83658f3f51777f302c59a6e'] = '消息';
 $_MODULE['<{wirecardpaymentgateway}prestashop>creditcard_submitform_93f05ad4c93885541f619d9bb1320106'] = '您正在重定向。请稍候';
+$_MODULE['<{wirecardpaymentgateway}prestashop>invoice_c78f9b2a75c840335bea59dcad2e4925'] = 'I herewith confirm that I have read the <a href=\"https://www.wirecardbank.com/privacy-documents/datenschutzhinweise-fuer-die-wirecard-zahlarten/\" target=\"_blank\">privacy notice</a> and <a target=\"_blank\" href=\"https://www.wirecardbank.com/privacy-documents/zusatzliche-geschaftsbedingungen-fur-wirecard-zahlarten/\">additional terms and conditions</a> for Wirecard payment types and that I accept their validity.';
+$_MODULE['<{wirecardpaymentgateway}prestashop>invoice_3471b47ae35836a5c315c049f13b211e'] = 'You must agree to the privacy notice and additional terms of Wirecard payment methods.';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepadirectdebit_65c55738e0d21515c1e026a8dd7eae21'] = '名';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepadirectdebit_b7250955039269f0611a6dab9c340ae9'] = '姓';
 $_MODULE['<{wirecardpaymentgateway}prestashop>sepadirectdebit_945122a0f892e1b60519029eff19f89e'] = 'IBAN';

--- a/wirecardpaymentgateway/views/js/invoice.js
+++ b/wirecardpaymentgateway/views/js/invoice.js
@@ -32,12 +32,30 @@ var form = null;
 
 $(document).ready(
     function () {
+        if ($('#payment-processing-gateway-ratepay-form').length > 0) {
+            setDataProtectionInfo();
+        }
         $(document).on('submit','#payment-form', function (e) {
             form = $(this);
+
             if (form.attr('action').search('invoice') >= 0) {
-                $('#invoiceDeviceIdent').attr('type', 'hidden').appendTo(form);
+                if ($('#invoiceDataProtectionCheckbox:checked').val() === '1') {
+                    $('#invoiceDeviceIdent').attr('type', 'hidden').appendTo(form);
+                } else {
+                    e.preventDefault();
+
+                    var hint = document.getElementById('invoiceDataProtectionHint');
+                    hint.style.display = "block";
+                }
             }
         });
+        function setDataProtectionInfo()
+        {
+            var dataProtectionLabelElement = $('#invoiceDataProtectionLabel');
+            var dataProtectionInfo = dataProtectionLabelElement.text();
+            dataProtectionLabelElement.text('');
+            dataProtectionLabelElement.append(dataProtectionInfo);
+        }
     }
 );
 

--- a/wirecardpaymentgateway/views/templates/front/invoice.tpl
+++ b/wirecardpaymentgateway/views/templates/front/invoice.tpl
@@ -32,4 +32,22 @@
 *}
 <div id="payment-processing-gateway-ratepay-form">
     <input type="hidden" class="form-control" name="invoiceDeviceIdent" id="invoiceDeviceIdent" value="{$deviceIdent|escape:'htmlall':'UTF-8'}"/>
+    <form id="invoiceDataProtection" method="GET">
+        <ul>
+            <li>
+                <div class="float-xs-left">
+                    <span class="custom-checkbox">
+                        <input id="invoiceDataProtectionCheckbox" name="invoiceDataProtectionCheckbox" required="" type="checkbox" value="1" class="ps-shown-by-js">
+                        <span><i class="material-icons rtl-no-flip checkbox-checked"></i></span>
+                    </span>
+                </div>
+                <div class="condition-label">
+                    <label id="invoiceDataProtectionLabel" for="invoiceDataProtectionCheckbox">
+                        {l s='text_terms_accept' mod='wirecardpaymentgateway'}
+                    </label>
+                </div>
+            </li>
+        </ul>
+        <small id="invoiceDataProtectionHint" class="text-danger" style="display: none;">{l s='text_terms_notice' mod='wirecardpaymentgateway'}</small>
+    </form>
 </div>

--- a/wirecardpaymentgateway/views/templates/front/payment_infos.tpl
+++ b/wirecardpaymentgateway/views/templates/front/payment_infos.tpl
@@ -29,6 +29,6 @@
  *}
 
 <section>
-  <p>{l s='if_additional_info_add_here' d='wirecardpaymentgateway'}
+  <p>{l s='if_additional_info_add_here' mod='wirecardpaymentgateway'}
   </p>
 </section>

--- a/wirecardpaymentgateway/views/templates/front/sepa_mandate.tpl
+++ b/wirecardpaymentgateway/views/templates/front/sepa_mandate.tpl
@@ -78,6 +78,7 @@
                                         {$creditorName|escape:'htmlall':'UTF-8'}
                                         {l s='sepa_text_2' mod='wirecardpaymentgateway'}
                                         {$creditorName|escape:'htmlall':'UTF-8'} {$additionalText|escape:'htmlall':'UTF-8'}
+                                        {l s='sepa_text_2b' mod='wirecardpaymentgateway'}
                                     </td>
                                     <td width="10%">&nbsp;</td>
                                 </tr>


### PR DESCRIPTION
### Notes

* Added checkbox with information text and links
* If the checkbox is not checked before payment submission a error hint will appear and the payment process does not continue
* After checking the payment process can be finished

### How to test

* Buy something via Wirecard Guaranteed Invoice by Wirecard
* Check "I agree to the terms of service and will adhere to them unconditionally."
* Click "Order with an obligation to pay" -> Error hint should be shown, no redirect
* Also check new checkbox and click at order button-> payment should proceed and a redirect should happen