### PR TITLE
Do not run Phraseapp check nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
     after_script: skip
     
   - stage: phraseapp-check-if-in-sync
-    if: branch = master OR type = pull_request
+    if: type != cron AND (branch = master OR type = pull_request)
     language: ruby
     ruby: 2.5.3
     before_install: skip


### PR DESCRIPTION
At the moment out nightly UI tests are no running because of the Phraseapp check error. This should not be an obstacle